### PR TITLE
Fix translating link types; fix merging sc-node types

### DIFF
--- a/src/translator/commands/set/sc_scn_tex_nrel_command.cpp
+++ b/src/translator/commands/set/sc_scn_tex_nrel_command.cpp
@@ -89,5 +89,6 @@ ScScnTexCommandResult ScSCnTexNRelCommand::Complete(
         stream.Attached("<- lang_ru", "=> nrel_format: format_html");
       else if (SCsHelper::IsURL(object))
         stream.Attached("<- concept_file", SCsHelper::GetFormat(object));
+      stream.SetCurrentCommand(relationType);
   });
 }

--- a/src/translator/identifiers-tree/sc_scn_prefix_tree.cpp
+++ b/src/translator/identifiers-tree/sc_scn_prefix_tree.cpp
@@ -12,10 +12,16 @@ ScSCnPrefixTree * ScSCnPrefixTree::GetInstance()
 
 std::string ScSCnPrefixTree::Add(std::string const & key, std::string const & nodeType)
 {
-  auto const & item = m_translations.find(key);
-  if (item != m_translations.end())
-    return item->second.first;
-
+  auto const & it = m_translations.find(key);
+  if (it != m_translations.end())
+  {
+    std::string const & identifier = it->second.first;
+    std::string const & type = it->second.second;
+    if (type == "sc_node")
+      m_translations[it->first] = {identifier, nodeType};
+    return identifier;
+  }
+  
   std::string const & value = ".system_element_" + std::to_string(index);
   m_translations.insert({ key, { value, nodeType } });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes translation of link types and merging of sc-node types in `sc_scn_tex_nrel_command.cpp` and `sc_scn_prefix_tree.cpp`.
> 
>   - **Behavior**:
>     - In `sc_scn_tex_nrel_command.cpp`, `Complete()` now sets the current command for the stream with `relationType`.
>     - In `sc_scn_prefix_tree.cpp`, `Add()` updates the node type if the key exists and the type is `sc_node`.
>   - **Misc**:
>     - Minor logic adjustments in `sc_scn_prefix_tree.cpp` to handle existing keys with `sc_node` type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Ftex2scs-translator&utm_source=github&utm_medium=referral)<sup> for 0ce588da7399cabe443a73aa101250ad6a0ce7ac. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->