### PR TITLE
[docs] Add doc strings for basic classes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,5 @@ kb
 .dockerignore
 Dockerfile
 README.md
+bin
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11.4-slim as base
+FROM debian:11.4-slim AS base
 
 USER root
 
@@ -13,9 +13,11 @@ RUN groupadd -g "${GID}" user && \
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 COPY ./scripts/install_deps_ubuntu.sh /tmp/install_deps_ubuntu.sh
-RUN /tmp/install_deps_ubuntu.sh --dev
+RUN /tmp/install_deps_ubuntu.sh
 
-FROM base as buildenv
+FROM base AS buildenv
+
+RUN /tmp/install_deps_ubuntu.sh --dev
 
 COPY . /tex2scs-translator
 RUN chown -R "${UID}:${GID}" /tex2scs-translator
@@ -31,4 +33,4 @@ USER user
 
 COPY --from=buildenv /tex2scs-translator /tex2scs-translator
 
-ENTRYPOINT ["/bin/bash", "-c", "./tex2scs-translator/bin/scn-tex2scs -d -c -s /kb -t /kb-translated"]
+ENTRYPOINT ["/bin/bash", "-c", "./tex2scs-translator/bin/scn-tex2scs -d -s /kb -t /kb-translated"]

--- a/scripts/install_deps_ubuntu.sh
+++ b/scripts/install_deps_ubuntu.sh
@@ -59,6 +59,3 @@ sudo apt-get update
 
 sudo apt-get install -y --no-install-recommends "${packages[@]}"
 sudo apt autoremove
-
-echo "Java installed at: $JAVA_HOME"
-java -version # Verify installation.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,16 @@
 
 #include "translator/sc_scn_tex2scs_translator.h"
 
+/*!
+ * @brief The main function of the tex2scs-translator application.
+ *
+ * The main function parses command-line arguments, sets up the translator, and runs the translation process.
+ * It also handles exceptions and provides usage information.
+ *
+ * @param argc The number of command-line arguments.
+ * @param argv An array of command-line argument strings.
+ * @return EXIT_SUCCESS if the translation process is successful, EXIT_FAILURE otherwise.
+ */
 int main(int argc, const char * argv[]) try
 {
   boost::program_options::options_description options_description("tex2scs-translator usage");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,4 +56,5 @@ int main(int argc, const char * argv[]) try
 catch (std::exception const & e)
 {
   std::cout << e.what() << std::endl;
+  return EXIT_FAILURE;
 }

--- a/src/translator/filesystem/sc_directory.h
+++ b/src/translator/filesystem/sc_directory.h
@@ -7,38 +7,126 @@
 
 class ScFile;
 
+/*!
+ * @brief Represents a directory in the file system.
+ *
+ * This class provides methods for interacting with directories, such as getting their path, checking if they exist,
+ * removing directories, copying files and directories, counting files with specific extensions, and iterating through
+ * the directory contents.
+ */
 class ScDirectory
 {
 public:
+  /*!
+   * @brief Constructs a ScDirectory object with the given path.
+   *
+   * @param path The path of the directory.
+   */
   ScDirectory(std::string path);
 
+  /*!
+   * @brief Returns the path of the directory.
+   *
+   * @return The path of the directory.
+   */
   [[nodiscard]] std::string GetPath() const;
 
+  /*!
+   * @brief Checks if the given path is a directory.
+   *
+   * @param path The path to check.
+   * @return True if the path is a directory, false otherwise.
+   */
   static bool IsDirectory(std::string const & path);
 
+  /*!
+   * @brief Removes the directory and all its contents.
+   */
   void RemoveDirectory();
 
+  /*!
+   * @brief Copies a file from the current directory to a new location.
+   *
+   * @param file The file to be copied.
+   * @param newExtension The new extension for the copied file (optional, default is "").
+   * @param copyContent Whether to copy the file content (optional, default is false).
+   * @return The copied file.
+   */
   [[nodiscard]] ScFile CopyFile(ScFile const & file, std::string newExtension = "", bool copyContent = false) const;
 
+  /*!
+   * @brief Copies a subdirectory from the current directory to a new location.
+   *
+   * @param nestedDirectoryPath The path of the subdirectory to be copied.
+   * @param targetDirectoryPath The path of the target directory where the subdirectory will be copied.
+   * @return The copied subdirectory.
+   */
   [[nodiscard]] ScDirectory CopyDirectory(std::string nestedDirectoryPath, std::string const & targetDirectoryPath) const;
 
+  /*!
+   * @brief Copies a subdirectory from the current directory to a new location.
+   *
+   * @param nestedDirectoryPath The path of the subdirectory to be copied.
+   * @param targetDirectory The target directory where the subdirectory will be copied.
+   * @return The copied subdirectory.
+   */
   [[nodiscard]] ScDirectory CopyDirectory(std::string const & nestedDirectoryPath, ScDirectory const & targetDirectory) const;
 
+  /*!
+   * @brief Counts the number of files in the directory with specific extensions.
+   *
+   * @param extensions The set of extensions to count.
+   * @return The number of files with the specified extensions.
+   */
   [[nodiscard]] size_t CountFiles(std::unordered_set<std::string> const & extensions) const;
 
+  /*!
+   * @brief Finds a file in the directory by its name.
+   *
+   * @param fileName The name of the file to find.
+   * @return The found file, or an empty ScFile object if the file is not found.
+   */
   [[nodiscard]] ScFile GetFileByName(std::string const & fileName) const;
 
+  /*!
+   * @brief Executes a callback function for each directory and file in the directory.
+   *
+   * @param directoryCallback The callback function to be executed for each directory.
+   * @param fileCallback The callback function to be executed for each file.
+   */
   void ForEach(
       std::function<void(ScDirectory const & directory)> const & directoryCallback,
       std::function<void(ScFile const & file)> const & fileCallback);
 
 private:
+  /*!
+   * @brief The path of the directory.
+   */
   std::string m_path;
+  /*!
+   * @brief The directory entry for the current directory.
+   *
+   * This field is used for interacting with the directory using the std::filesystem library.
+   */
   std::filesystem::directory_entry m_entry;
 
+  /*!
+   * @brief Constructs the full path of a file within the directory.
+   *
+   * @param workDirectory The current working directory.
+   * @param fileName The name of the file.
+   * @return The full path of the file.
+   */
   std::string PathFiles(
       std::string const & workDirectory, std::string const & fileName) const;
 
+  /*!
+   * @brief Recursively counts the number of files with specific extensions within the directory.
+   *
+   * @param workDirectory The current working directory.
+   * @param count A reference to the count of files with the specified extensions.
+   * @param extensions The set of extensions to count.
+   */
   void PathFiles(
       std::string const & workDirectory, size_t & count, std::unordered_set<std::string> const & extensions) const;
 };

--- a/src/translator/filesystem/sc_file.h
+++ b/src/translator/filesystem/sc_file.h
@@ -3,21 +3,63 @@
 #include <string>
 #include <unordered_set>
 
+/*!
+ * @brief Represents a file in the file system.
+ *
+ * This class provides methods for interacting with files, such as getting their path, name, extension,
+ * reading and writing their content, and checking if they have specific extensions.
+ */
 class ScFile
 {
 public:
+  /*!
+   * @brief Constructs a ScFile object with the given path.
+   *
+   * @param path The path of the file.
+   */
   ScFile(std::string path);
 
+  /*!
+   * @brief Returns the path of the file.
+   *
+   * @return The path of the file.
+   */
   [[nodiscard]] std::string GetPath() const;
 
+  /*!
+   * @brief Writes the given text to the file.
+   *
+   * @param text The text to be written to the file.
+   */
   void Write(std::string const & text);
 
+  /*!
+   * @brief Reads the content of the file into the given stringstream.
+   *
+   * @param text The stringstream to store the file content.
+   */
   void Read(std::stringstream & text) const;
 
+  /*!
+   * @brief Returns the name of the file without the extension.
+   *
+   * @return The name of the file.
+   */
   [[nodiscard]] std::string GetName() const;
 
+  /*!
+   * @brief Returns the extension of the file.
+   *
+   * @return The extension of the file.
+   */
   [[nodiscard]] std::string GetExtension() const;
 
+  /*!
+   * @brief Checks if the file has any of the specified extensions.
+   *
+   * @param extensions The set of extensions to check against.
+   * @return True if the file has any of the specified extensions, false otherwise.
+   */
   [[nodiscard]] bool HasExtension(std::unordered_set<std::string> const & extensions) const;
 
 private:

--- a/src/translator/identifiers-tree/sc_scn_prefix_tree.h
+++ b/src/translator/identifiers-tree/sc_scn_prefix_tree.h
@@ -5,29 +5,82 @@
 
 #include "translator/commands/sc_scn_tex2scs_translations.h"
 
+/*!
+ * @brief Represents a prefix tree for managing identifiers in scn-text.
+ *
+ * This class provides methods for adding, retrieving, and managing identifiers in a prefix tree structure.
+ * It also provides a method for dumping the tree structure for debugging purposes.
+ */
 class ScSCnPrefixTree
 {
 public:
+  /*!
+   * @brief Destructor.
+   *
+   * Frees the allocated memory for the prefix tree.
+   */
   ~ScSCnPrefixTree();
 
+  /*!
+   * @brief Returns the singleton instance of the ScSCnPrefixTree class.
+   *
+   * @return The singleton instance of ScSCnPrefixTree.
+   */
   static ScSCnPrefixTree & GetInstance();
 
+  /*!
+   * @brief Adds a new identifier to the prefix tree.
+   *
+   * @param key The key (identifier) to be added.
+   * @param nodeType The type of the node (e.g., "sc_node", "sc_node_class", etc.).
+   * @return The unique identifier (sys_id) of the added node.
+   */
   std::string Add(std::string const & key, std::string const & nodeType);
 
+  /*!
+   * @brief Retrieves the value associated with the given key from the prefix tree.
+   *
+   * @param key The key (identifier) to retrieve the value for.
+   * @return The value associated with the given key, or an empty string if the key is not found.
+   */
   std::string Get(std::string const & key);
 
+  /*!
+   * @brief Sets the new element system identifier for the prefix tree.
+   *
+   * @param elementSysId The new element system identifier.
+   */
   void SetNewElementNumber(size_t elementSysId);
 
+  /*!
+   * @brief Retrieves a free element system identifier from the prefix tree.
+   *
+   * @return A free element system identifier, or an empty string if no free identifier is available.
+   */
   std::string GetFreeElementSystemIdentifier();
 
+  /*!
+   * @brief Dumps the prefix tree structure for debugging purposes.
+   *
+   * @return A string representation of the prefix tree structure.
+   */
   std::string Dump() const;
 
 protected:
+  /*!
+   * @brief A pointer to the singleton instance of ScSCnPrefixTree.
+   */
   static std::unique_ptr<ScSCnPrefixTree> m_instance;
 
+  /*!
+   * @brief Constructor.
+   *
+   * Initializes the prefix tree with default values.
+   */
   ScSCnPrefixTree();
 
 private:
-  long long index;
-  ScSCnTexTranslations m_translations;
+  long long index; ///< The index for generating unique identifiers.
+
+  ScSCnTexTranslations m_translations; ///< The translations for SCn TeX commands.
 };

--- a/src/translator/sc_scn_tex2scs_translator.h
+++ b/src/translator/sc_scn_tex2scs_translator.h
@@ -11,31 +11,70 @@ class ScDirectory;
 
 using ScSCnTexCommands = std::unordered_map<std::string, ScSCnTexCommand *>;
 
-class ScSCnTex2SCsTranslator
-{
+/*!
+ * @brief The ScSCnTex2SCsTranslator class is responsible for translating sc.n-represented *.tex files into *.scs files.
+ *
+ * The class provides methods for running the translation process, handling debug and clear modes, and managing the translation progress.
+ * It also includes private methods for translating individual files, dumping identifiers, and dumping file structures.
+ */
+class ScSCnTex2SCsTranslator {
+private:
+  bool m_debugMode; ///< Indicates whether the translator should run in debug mode.
+  bool m_clearMode; ///< Indicates whether the target directory should be cleared before translation.
+  std::unordered_set<std::string> m_extensions = { ".tex" }; ///< The file extensions to be translated.
+  size_t m_filesCount = 0; ///< The total number of files to be translated.
+  size_t m_fileNumber = 0; ///< The current file number being translated.
+
 public:
+  /*!
+   * @brief Constructs a ScSCnTex2SCsTranslator object.
+   * @param debugMode Indicates whether the translator should run in debug mode.
+   * @param clearMode Indicates whether the target directory should be cleared before translation.
+   */
   ScSCnTex2SCsTranslator(bool debugMode, bool clearMode);
 
+  /*!
+   * @brief Runs the translation process.
+   * @param workDirectoryPath The path to the directory containing the sc.n-represented *.tex files.
+   * @param targetDirectoryPath The path to the directory where the translated *.scs files will be saved.
+   * @param elementSysId The starting element system identifier for the translation.
+   * @return True if the translation process is successful, false otherwise.
+   */
   bool Run(std::string const & workDirectoryPath, std::string const & targetDirectoryPath, size_t elementSysId);
 
 private:
-  bool m_debugMode;
-  bool m_clearMode;
+  /*!
+   * @brief Translates all files within a given directory and its subdirectories.
+   * @param nestedDirectoryPath The path to the directory to be translated.
+   * @param startDirectory The original starting directory for the translation.
+   * @param startTargetDirectory The original target directory for the translation.
+   */
+  void TranslateFiles(std::string const & nestedDirectoryPath, ScDirectory startDirectory, ScDirectory const & startTargetDirectory);
 
-  std::unordered_set<std::string> m_extensions = {".tex"};
-  size_t m_filesCount;
-  size_t m_fileNumber;
-
-  void TranslateFiles(
-      std::string const & nestedDirectoryPath,
-      ScDirectory startDirectory,
-      ScDirectory const & startTargetDirectory);
-
+  /*!
+   * @brief Translates a single file from sc.n-represented *.tex to *.scs.
+   * @param file The file to be translated.
+   * @param targetDirectory The target directory where the translated file will be saved.
+   * @return True if the file is successfully translated, false otherwise.
+   */
   bool TranslateFile(ScFile const & file, ScDirectory const & targetDirectory);
 
+  /*!
+   * @brief Translates the text content of a sc.n-represented *.tex file into the corresponding *.scs text.
+   * @param filePath The path to the sc.n-represented *.tex file.
+   * @return The translated *.scs text.
+   */
   std::string TranslateText(std::string const & filePath);
 
+  /*!
+   * @brief Dumps the identifiers used during the translation process into a file.
+   * @param targetDirectory The target directory where the identifiers file will be saved.
+   */
   void DumpIdentifiers(ScDirectory const & targetDirectory);
 
+  /*!
+   * @brief Dumps the file structures used during the translation process into separate files.
+   * @param targetDirectory The target directory where the file structures will be saved.
+   */
   void DumpFileStructs(ScDirectory const & targetDirectory);
 };

--- a/src/translator/stream/scs_stream.h
+++ b/src/translator/stream/scs_stream.h
@@ -9,11 +9,30 @@
 
 #include "translator/stream/sc_string_stream.h"
 
+/*!
+ * @brief The SCsStream class is responsible for generating sc-stream text for the translator.
+ *
+ * The SCsStream class provides methods for formatting and structuring the sc-stream text,
+ * as well as for attaching additional information to the text.
+ *
+ * The class supports various formatting options, such as row formatting, offset formatting,
+ * and tabulation. It also allows for setting the current command and defining attached information.
+ *
+ * The SCsStream class is designed to be used in conjunction with the ScSCnTex2SCsTranslator class,
+ * which performs the actual translation of sc.n-represented *.tex files into *.scs files.
+ */
 class SCsStream : protected ScStringStream
 {
 public:
+  /*!
+   * @brief Constructs an SCsStream object with no initial content.
+   */
   SCsStream();
 
+  /*!
+   * @brief Constructs an SCsStream object with the provided initial strings.
+   * @param args The initial strings to be added to the SCsStream.
+   */
   template <typename... Args>
   SCsStream(Args const &... args)
   {
@@ -23,32 +42,100 @@ public:
       *this << item;
   }
 
+  /*!
+   * @brief Overloads the << operator to add a string to the SCsStream.
+   * @param string The string to be added to the SCsStream.
+   * @return A reference to the SCsStream object.
+   */
   SCsStream & operator<< (std::string const & string) override;
 
+  /*!
+   * @brief Adds a row to the SCsStream using a provided function.
+   * @param row A function that generates the row content.
+   * @return A reference to the SCsStream object.
+   */
   SCsStream & Row(std::function<void(SCsStream &)> const & row);
 
+  /*!
+   * @brief Adds a row to the SCsStream using a provided function.
+   * @param row A function that generates the row content.
+   * @return A reference to the SCsStream object.
+   */
   SCsStream & Row(std::function<SCsStream()> const & row);
 
+  /*!
+   * @brief Adds an offset to the SCsStream using a provided function.
+   * @param formatted A function that generates the offset content.
+   * @return A reference to the SCsStream object.
+   */
   SCsStream & Offset(std::function<void(SCsStream &)> const & formatted);
 
+  /*!
+   * @brief Adds an offset to the SCsStream using a provided function.
+   * @param formatted A function that generates the offset content.
+   * @return A reference to the SCsStream object.
+   */
   SCsStream & Offset(std::function<SCsStream()> const & formatted);
 
+  /*!
+   * @brief Adds formatted content to the SCsStream using a provided function.
+   * @param formatted A function that generates the formatted content.
+   * @return A reference to the SCsStream object.
+   */
   SCsStream & Formatted(std::function<void(SCsStream &)> const & formatted);
 
+  /*!
+   * @brief Adds pre-formatted content to the SCsStream using a provided function.
+   * @param formatted A function that generates the pre-formatted content.
+   * @return A reference to the SCsStream object.
+   */
   SCsStream & PreFormatted(std::function<void(SCsStream &)> const & formatted = {});
 
+  /*!
+   * @brief Adds formatted content to the SCsStream using a provided function.
+   * @param formatted A function that generates the formatted content.
+   * @return A reference to the SCsStream object.
+   */
   SCsStream & Formatted(std::function<SCsStream()> const & formatted);
 
+  /*!
+   * @brief Adds tabulated content to the SCsStream using a provided function.
+   * @param tabulated A function that generates the tabulated content.
+   * @return A reference to the SCsStream object.
+   */
   SCsStream & Tabulated(std::function<void(SCsStream &)> const & tabulated);
 
+  /*!
+   * @brief Adds tabulated content to the SCsStream using a provided function.
+   * @param tabulated A function that generates the tabulated content.
+   * @return A reference to the SCsStream object.
+   */
   SCsStream & Tabulated(std::function<SCsStream()> const & tabulated);
 
+  /*!
+   * @brief Adds a tab to the SCsStream.
+   * @return A reference to the SCsStream object.
+   */
   SCsStream & AddTab();
 
+  /*!
+   * @brief Removes a tab from the SCsStream.
+   * @return A reference to the SCsStream object.
+   */
   SCsStream & RemoveTab();
 
+  /*!
+   * @brief Sets the current command for the SCsStream.
+   * @param name The name of the current command.
+   * @return A reference to the SCsStream object.
+   */
   SCsStream & SetCurrentCommand(std::string const & name = "any");
 
+  /*!
+   * @brief Adds attached information to the SCsStream using the provided strings.
+   * @param args The attached information to be added to the SCsStream.
+   * @return A reference to the SCsStream object.
+   */
   template <typename... Args>
   SCsStream & Attached(Args const &... args)
   {
@@ -59,41 +146,90 @@ public:
     return *this;
   }
 
+  /*!
+   * @brief Clears the SCsStream object, resetting its internal state.
+   */
   static void Clear();
 
+  /*!
+   * @brief Converts the SCsStream object to a string.
+   * @return The SCsStream content as a string.
+   */
   operator std::string() override;
 
 private:
-  static std::string m_offset;
-  static uint32_t m_indent;
-  static std::string m_semicolons;
-  static std::string m_currentCommand;
-  static std::string m_lastCommand;
+  static std::string m_offset; ///< The offset for the SCsStream.
+  static uint32_t m_indent;   ///< The indentation level for the SCsStream.
+  static std::string m_semicolons; ///< The semicolons for the SCsStream.
+  static std::string m_currentCommand; ///< The current command for the SCsStream.
+  static std::string m_lastCommand; ///< The last command for the SCsStream.
 
-  static std::vector<std::string> m_attached;
+  static std::vector<std::string> m_attached; ///< The attached information for the SCsStream.
 
-  static std::unordered_map<std::string, std::vector<std::string>> m_formats;
-  static std::unordered_set<std::string> m_begins;
+  static std::unordered_map<std::string, std::vector<std::string>> m_formats; ///< The formatting options for the SCsStream.
+  static std::unordered_set<std::string> m_begins; ///< The command list header begin names for the SCsStream.
 
+  /*!
+   * @brief Prepares the SCsStream object for formatting.
+   */
   void PreFormat();
 
+  /*!
+   * @brief Defines the semicolons for the SCsStream object.
+   * @return The semicolons as a string.
+   */
   static std::string DefineSemicolons();
 
+  /*!
+   * @brief Adds a tab to the SCsStream.
+   */
   static void Tab();
 
+  /*!
+   * @brief Removes a tab from the SCsStream.
+   */
   static void Untab();
 
+  /*!
+   * @brief Sets the double semicolons for the SCsStream object.
+   */
   static void SetDoubleSemicolons();
 
+  /*!
+   * @brief Unsets the double semicolons for the SCsStream object.
+   */
   static void UnsetDoubleSemicolons();
 
+  /*!
+   * @brief Defines the endline for the SCsStream object.
+   * @return The endline as a string.
+   */
   static std::string DefineEndline();
 
+  /*!
+   * @brief Defines the offset for the SCsStream object.
+   * @return The offset as a string.
+   */
   static std::string DefineOffset();
 
+  /*!
+   * @brief Checks if the given name is a command header.
+   * @param name The name to check.
+   * @return True if the name is a command header, false otherwise.
+   */
   static bool IsCommandHeader(std::string const & name);
 
+  /*!
+   * @brief Checks if the given name is the beginning of a command list header.
+   * @param name The name to check.
+   * @return True if the name is the beginning of a command list header, false otherwise.
+   */
   static bool IsCommandListHeaderBegin(std::string const & name);
 
+  /*!
+   * @brief Checks if the given name is the end of a command list header.
+   * @param name The name to check.
+   * @return True if the name is the end of a command list header, false otherwise.
+   */
   static bool IsCommandListHeaderEnd(std::string const & name);
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add comprehensive docstrings to key classes and functions across multiple files for improved documentation.
> 
>   - **Documentation**:
>     - Add docstring for `main()` in `main.cpp` describing its purpose, parameters, and return values.
>     - Add docstrings for `ScDirectory` class in `sc_directory.h`, detailing methods like `GetPath()`, `IsDirectory()`, `RemoveDirectory()`, and others.
>     - Add docstrings for `ScFile` class in `sc_file.h`, covering methods such as `GetPath()`, `Write()`, `Read()`, and others.
>     - Add docstrings for `ScSCnPrefixTree` class in `sc_scn_prefix_tree.h`, explaining methods like `Add()`, `Get()`, `SetNewElementNumber()`, and others.
>     - Add docstrings for `ScSCnTex2SCsTranslator` class in `sc_scn_tex2scs_translator.h`, describing methods like `Run()`, `TranslateFiles()`, `TranslateFile()`, and others.
>     - Add docstrings for `SCsStream` class in `scs_stream.h`, detailing methods such as `operator<<`, `Row()`, `Offset()`, and others.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Ftex2scs-translator&utm_source=github&utm_medium=referral)<sup> for 6c80475f3800300c3f617b3359ed18f9b9fee3cb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->